### PR TITLE
Add email sign-in option

### DIFF
--- a/library-compose/src/main/java/dev/muuli/gtd/library/compose/MainViewActivity.kt
+++ b/library-compose/src/main/java/dev/muuli/gtd/library/compose/MainViewActivity.kt
@@ -65,11 +65,11 @@ fun MainView(viewModel: AuthViewModel) {
                     },
                     colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary),
                     actions = {
-                        IconButton (onClick = { viewModel.signOut() }) {
+                        IconButton(onClick = { viewModel.signOut() }) {
                             Icon(
-                                imageVector = Icons.AutoMirrored.Filled.ExitToApp, // Replace with your actual icon
+                                imageVector = Icons.AutoMirrored.Filled.ExitToApp,
                                 contentDescription = "Sign Out",
-                                tint = MaterialTheme.colorScheme.onPrimary // Or Color.White, Color.Black etc. for testing
+                                tint = MaterialTheme.colorScheme.onPrimary,
                             )
                         }
                     }

--- a/library-compose/src/main/java/dev/muuli/gtd/library/compose/auth/SignInScreen.kt
+++ b/library-compose/src/main/java/dev/muuli/gtd/library/compose/auth/SignInScreen.kt
@@ -2,6 +2,7 @@ package dev.muuli.gtd.library.compose.auth
 
 import android.app.Activity
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -28,17 +29,38 @@ fun SignInScreen(viewModel: AuthViewModel) {
     }
 
     if (user == null) {
-        Button(onClick = {
-            val providers = arrayListOf(
-                AuthUI.IdpConfig.GoogleBuilder().build()
-            )
-            val signInIntent = AuthUI.getInstance()
-                .createSignInIntentBuilder()
-                .setAvailableProviders(providers)
-                .build()
-            launcher.launch(signInIntent)
-        }) {
-            Text(text = "Sign in with Google", style = MaterialTheme.typography.bodyLarge)
+        Column {
+            Button(onClick = {
+                val providers = arrayListOf(
+                    AuthUI.IdpConfig.GoogleBuilder().build()
+                )
+                val signInIntent = AuthUI.getInstance()
+                    .createSignInIntentBuilder()
+                    .setAvailableProviders(providers)
+                    .build()
+                launcher.launch(signInIntent)
+            }) {
+                Text(
+                    text = "Sign in with Google",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            }
+
+            Button(onClick = {
+                val providers = arrayListOf(
+                    AuthUI.IdpConfig.EmailBuilder().build()
+                )
+                val signInIntent = AuthUI.getInstance()
+                    .createSignInIntentBuilder()
+                    .setAvailableProviders(providers)
+                    .build()
+                launcher.launch(signInIntent)
+            }) {
+                Text(
+                    text = "Sign in with Email",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            }
         }
     } else {
         Button(onClick = { viewModel.signOut() }) {


### PR DESCRIPTION
## Summary
- allow signing in with email in the SignInScreen
- tidy MainViewActivity code to satisfy detekt

## Testing
- `./gradlew detekt --auto-correct`
- `./gradlew check` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877f2494f68832383ac63d94e520fed