### PR TITLE
Add UI tests for sign-in and sign-out

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,8 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 hilt-android-gradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "hilt" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+# Library for using Hilt in instrumentation tests
+hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 # For Hilt Navigation Compose (optional, but often useful)
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version = "1.2.0" }
 

--- a/library-compose/build.gradle.kts
+++ b/library-compose/build.gradle.kts
@@ -83,4 +83,6 @@ dependencies {
     androidTestImplementation(libs.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.hilt.android.testing)
+    kaptAndroidTest(libs.hilt.compiler)
 }

--- a/library-compose/src/androidTest/java/dev/muuli/gtd/library/compose/FakeAuthRepository.kt
+++ b/library-compose/src/androidTest/java/dev/muuli/gtd/library/compose/FakeAuthRepository.kt
@@ -1,0 +1,21 @@
+package dev.muuli.gtd.library.compose
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import dev.muuli.gtd.library.compose.auth.AuthRepository
+import io.mockk.mockk
+
+class FakeAuthRepository : AuthRepository(mockk<FirebaseAuth>(relaxed = true)) {
+    private var user: FirebaseUser? = null
+
+    override val currentUser: FirebaseUser?
+        get() = user
+
+    fun setUser(fakeUser: FirebaseUser?) {
+        user = fakeUser
+    }
+
+    override fun signOut() {
+        user = null
+    }
+}

--- a/library-compose/src/androidTest/java/dev/muuli/gtd/library/compose/MainViewActivityTest.kt
+++ b/library-compose/src/androidTest/java/dev/muuli/gtd/library/compose/MainViewActivityTest.kt
@@ -1,0 +1,80 @@
+package dev.muuli.gtd.library.compose
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.google.firebase.auth.FirebaseUser
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
+import dagger.hilt.components.SingletonComponent
+import io.mockk.every
+import io.mockk.mockk
+import javax.inject.Inject
+import javax.inject.Singleton
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@HiltAndroidTest
+@UninstallModules(AuthModule::class)
+class MainViewActivityTest {
+
+    @Module
+    @InstallIn(SingletonComponent::class)
+    object TestAuthModule {
+        @Provides
+        @Singleton
+        fun provideAuthRepository(): FakeAuthRepository = FakeAuthRepository()
+    }
+
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<TestMainViewActivity>()
+
+    @Inject
+    lateinit var repository: FakeAuthRepository
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun signInDisplaysMainView() {
+        composeRule.onNodeWithText("Sign in with Google").assertIsDisplayed()
+
+        val user = mockk<FirebaseUser>(relaxed = true) {
+            every { email } returns "test@example.com"
+        }
+        repository.setUser(user)
+
+        composeRule.runOnUiThread {
+            composeRule.activity.testViewModel.onSignInResult()
+        }
+
+        composeRule.onNodeWithText("You are logged in").assertExists()
+    }
+
+    @Test
+    fun signOutShowsSignInButtons() {
+        val user = mockk<FirebaseUser>(relaxed = true) {
+            every { email } returns "test@example.com"
+        }
+        repository.setUser(user)
+        composeRule.runOnUiThread {
+            composeRule.activity.testViewModel.onSignInResult()
+        }
+
+        composeRule.onNodeWithContentDescription("Sign Out").performClick()
+
+        composeRule.onNodeWithText("Sign in with Google").assertIsDisplayed()
+    }
+}

--- a/library-compose/src/androidTest/java/dev/muuli/gtd/library/compose/TestMainViewActivity.kt
+++ b/library-compose/src/androidTest/java/dev/muuli/gtd/library/compose/TestMainViewActivity.kt
@@ -1,0 +1,18 @@
+package dev.muuli.gtd.library.compose
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import dev.muuli.gtd.library.compose.auth.AuthViewModel
+
+@AndroidEntryPoint
+class TestMainViewActivity : ComponentActivity() {
+    val testViewModel: AuthViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent { MainView(testViewModel) }
+    }
+}


### PR DESCRIPTION
## Summary
- add Hilt instrumentation dependency
- provide FakeAuthRepository for tests
- create TestMainViewActivity for exposing ViewModel
- test sign-in and sign-out behaviour

## Testing
- `./gradlew detekt --auto-correct`
- `./gradlew check` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879be51e04c8323a43ff352f6227abc